### PR TITLE
FIX for UIResponder Warning

### DIFF
--- a/Classes/MMNumberKeyboard.m
+++ b/Classes/MMNumberKeyboard.m
@@ -333,7 +333,7 @@ static const CGFloat MMNumberKeyboardPadSpacing = 8.0f;
 
 - (void)_dismissKeyboard:(id)sender
 {
-    UIResponder *firstResponder = self.keyInput;
+    UIResponder *firstResponder = (UIResponder*) self.keyInput;
     if (firstResponder) {
         [firstResponder resignFirstResponder];
     }


### PR DESCRIPTION
fix for initializing ‘UIResponder *_strong’ with an expression of incompatible type ‘id<UIKeyInput>'